### PR TITLE
fix cipher suite not matching on group policy list

### DIFF
--- a/AzureDevOpsTls12Analysis.ps1
+++ b/AzureDevOpsTls12Analysis.ps1
@@ -231,7 +231,7 @@ function CheckFunctionsList
             $result = @()
             foreach ($item in $valueList)
             {
-                if ($list -contains $item) { $result = $result + $item }
+                if ([bool]($list -match $item)) { $result = $result + $item }
             }
             return ($true, $result)
         }


### PR DESCRIPTION
Group policy list is separated by commas instead of spaces and fails on the `-contains` check

![MicrosoftTeams-image](https://user-images.githubusercontent.com/2416676/159965602-518aca4d-cfa0-4f66-a6ba-3df7c67a1fe6.png)
